### PR TITLE
Fix CI spellcheck

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = colour, metre
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./cad,./doc
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =


### PR DESCRIPTION
Ignore `cad` and `doc` subfolders.